### PR TITLE
docs: Fix typos in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Updates cells with the specified data (at the specified range)
   - data:string - The data to be used as a JSON string - nested array [["1", "2", "3"]]
   - [spreadsheetId]?:string - The id of the spreadsheet (needed if no previous command set the spreadsheetId globally)
   - [minRow=1]?:number - Starting row of the operation
-  - [minCol=1]?:number - Starting row of the operation
+  - [minCol=1]?:number - Starting column of the operation
   - [range]?:string - Range in a1 notation to be used for the operation
   - [valueInputOption=RAW]?:string - The input value to be used
   - [worksheetTitle]?:string - The title of the worksheet (needed if no previous command set the worksheetTitle globally)
@@ -121,7 +121,7 @@ Append cells with the specified data after the last row (in starting col)
 - args
   - data:string - The data to be used as a JSON string - nested array [["1", "2", "3"]]
   - [spreadsheetId]?:string - The id of the spreadsheet (needed if no previous command set the spreadsheetId globally)
-  - [minCol=1]?:number - Starting row of the operation
+  - [minCol=1]?:number - Starting column of the operation
   - [range]?:string - Range in a1 notation to be used for the operation
   - [valueInputOption=RAW]?:string - The input value to be used
   - [worksheetTitle]?:string - The title of the worksheet (needed if no previous command set the worksheetTitle globally)
@@ -133,9 +133,9 @@ Get cell data (within specified range)
 - args
   - [spreadsheetId]?:string - The id of the spreadsheet (needed if no previous command set the spreadsheetId globally)
   - [minRow=1]?:number - Starting row of the operation
-  - [minCol=1]?:number - Starting row of the operation
+  - [minCol=1]?:number - Starting column of the operation
   - [maxRow]?:number - Last row of the operation
-  - [maxCol]?:number - Last row of the operation
+  - [maxCol]?:number - Last column of the operation
   - [range]?:string - Range in a1 notation to be used for the operation
   - [hasHeaderRow]?:boolean - If the first row should be treated as header row
   - [worksheetTitle]?:string - The title of the worksheet (needed if no previous command set the worksheetTitle globally)


### PR DESCRIPTION
Fix copy/paste typos in `README.md`.

### Notes for the reviewer

I've also noticed that the example in a README uses version `1.0.0` of this action

https://github.com/jroehl/gsheet.action/blob/076b80b278080fbed8d144e1ebbb2296a0cd7650/README.md?plain=1#L43

while a newer version `1.2.0` is available. Should this line be updated as well?