### PR TITLE
Add docs for acquiring credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Secrets required as environment variables
 - GSHEET_CLIENT_EMAIL (email of the service account that has permission to access the spreadsheet)
 - GSHEET_PRIVATE_KEY (private key of the service account that has permission to access the spreadsheet)
 
+In order to get these credentials you will need to:
+1. Create a project in the Google Developer Console with permissions for Google Sheets API
+2. Create a Service Account for this project
+3. Generate a key for the service account in JSON format and download the file. Inside will be the `client_email` and `private_key`
+
 ### Setup in github action workflow (v2)
 
 ```yaml


### PR DESCRIPTION
## Purpose

It wasn't quite clear to me which key and email I needed for this. I was first trying to use my personal email for my Google account but eventually I discovered how to generate the correct credentials. I figured it would be useful to add some docs for this so that other folks can get on the right track with this. There has also been [some confusion](https://github.com/jroehl/gsheet.action/issues/75) about this in the past which this will hopefully help prevent.

## Dependencies and/or References

[Google's documentation](https://cloud.google.com/iam/docs/service-accounts) on Service Accounts
