### PR TITLE
feature: Add outputFile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,32 @@ jobs:
         run: echo "$RESULTS" | jq
 ```
 
+If you are getting a lot of data from a spreadsheet, the output may be too large. In this case you can write the results to a file:
+
+```yaml
+name: gsheet.action test
+on: push
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+      - id: 'update_worksheet'
+        uses: jroehl/gsheet.action@v2.0.0 # you can specify '@release' to always have the latest changes
+        with:
+          spreadsheetId: <spreadsheetId>
+          commands: | # list of commands, specified as a valid JSON string
+            [
+              { "command": "getData", "args": { "range": "'<worksheetTitle>'!A:Z" } }
+            ]
+          outputFile: /tmp/gsheet_action_results.json
+        env:
+          GSHEET_CLIENT_EMAIL: ${{ secrets.GSHEET_CLIENT_EMAIL }}
+          GSHEET_PRIVATE_KEY: ${{ secrets.GSHEET_PRIVATE_KEY }}
+      - name: echo results
+        run: echo /tmp/gsheet_action_results.json | jq
+```
+
 > See ./github/workflows/e2e.yml for another example.
 
 ## Supported commands

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
         { "command": "updateData", "args": { "data": [["A1", "A2", "A3"]] }}
       ]'
     required: true
+  outputFile:
+    description: 'Optional. The path to a file to write the output to. Useful if the output is too large for GitHub Actions.'
+    required: false
 outputs:
   results:
     description: 'The results of all commands as an array'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import { debug, getInput, setFailed, setOutput } from '@actions/core';
 import GoogleSheet from 'google-sheet-cli/lib/lib/google-sheet';
 import { ValidatedCommand, asyncForEach, validateCommands } from './lib';
@@ -45,7 +46,16 @@ export default async function run(): Promise<Results> {
       }
     );
 
-    setOutput('results', JSON.stringify({ results }));
+    const output = JSON.stringify({ results });
+
+    const outputFile: string = getInput('outputFile', {
+      required: false,
+    });
+    if (outputFile) {
+      fs.writeFileSync(outputFile, output);
+    }
+
+    setOutput('results', output);
     // eslint-disable-next-line i18n-text/no-en
     debug(`Processed commands\n${JSON.stringify(results, null, 2)}`);
     return { results };


### PR DESCRIPTION
## Purpose

Add an optional `outputFile` parameter. If specified, the output of all commands will be written to this file, as well as to the GitHub Action output.

This can be useful when reading large amounts of data from google sheets - you will reach the limit of how much data can be put into a shell ENV var to pass to the next step.

## Dependencies and/or References

-

## TODOs

Note that I had to upgrade the Semantic Versioning GHA step on my fork to use Node 20, as it no longer supports Node 18.

## Review

### Notes for the PR owner

<https://seesparkbox.com/foundry/github_pull_requests_for_everyone>

### Notes for the reviewer

<https://seesparkbox.com/foundry/stop_giving_depressing_code_reviews>
